### PR TITLE
Fix/on ground dynamic object confusion

### DIFF
--- a/silly-sam/sam.lua
+++ b/silly-sam/sam.lua
@@ -30,6 +30,7 @@ function Sam:init(world, mapObject)
     self.chest.height = 60
     self.chest.image = love.graphics.newImage("assets/art/sam-textures/chest.png")
     self.chest.body = love.physics.newBody(world, spawn.x, spawn.y, "dynamic")
+    self.chest.body:setUserData("samBodyPart")
     self.chest.shape = love.physics.newRectangleShape(self.chest.width, self.chest.height)
     self.chest.fixture = love.physics.newFixture(self.chest.body, self.chest.shape);
     self.chest.fixture:setFriction(0.5)
@@ -43,6 +44,7 @@ function Sam:init(world, mapObject)
     self.leftLeg.height = 45
     self.leftLeg.image = love.graphics.newImage("assets/art/sam-textures/leg-left.png")
     self.leftLeg.body = love.physics.newBody(world, spawn.x-20, spawn.y+60, "dynamic")
+    self.leftLeg.body:setUserData("samBodyPart")
     self.leftLeg.shape = love.physics.newRectangleShape(self.leftLeg.width, self.leftLeg.height)
     self.leftLeg.fixture = love.physics.newFixture(self.leftLeg.body, self.leftLeg.shape, 3);
     self.leftLeg.fixture:setFriction(0.5)
@@ -66,6 +68,7 @@ function Sam:init(world, mapObject)
     self.rightLeg.height = 45
     self.rightLeg.image = love.graphics.newImage("assets/art/sam-textures/leg-right.png")
     self.rightLeg.body = love.physics.newBody(world, spawn.x+20, spawn.y+60, "dynamic")
+    self.rightLeg.body:setUserData("samBodyPart")
     self.rightLeg.shape = love.physics.newRectangleShape(self.rightLeg.width, self.rightLeg.height)
     self.rightLeg.fixture = love.physics.newFixture(self.rightLeg.body, self.rightLeg.shape, 3);
     self.rightLeg.fixture:setFriction(0.5)
@@ -86,6 +89,7 @@ function Sam:init(world, mapObject)
     self.head = {}
     self.head.image = love.graphics.newImage("assets/art/sam-textures/face.png")
     self.head.body = love.physics.newBody(world, spawn.x, spawn.y-55, "dynamic")
+    self.head.body:setUserData("samBodyPart")
     self.head.shape = love.physics.newCircleShape(15)
     self.head.fixture = love.physics.newFixture(self.head.body, self.head.shape, 0.5);
     self.head.fixture:setFriction(0.5)
@@ -98,6 +102,7 @@ function Sam:init(world, mapObject)
     -- chin (not visible, for weighting)
     self.chin = {}
     self.chin.body = love.physics.newBody(world, spawn.x, spawn.y-35, "dynamic")
+    self.chin.body:setUserData("samBodyPart")
     self.chin.shape = love.physics.newCircleShape(4)
     self.chin.body:setMass(1000)
     self.chin.fixture = love.physics.newFixture(self.chin.body, self.chin.shape, 0.5);
@@ -114,6 +119,7 @@ function Sam:init(world, mapObject)
     self.toupee.height = 7.3
     self.toupee.image = love.graphics.newImage("assets/art/sam-textures/toupee.png")
     self.toupee.body = love.physics.newBody(world, spawn.x, spawn.y-74, "dynamic")
+    self.toupee.body:setUserData("samBodyPart")
     self.toupee.body:setMass(0)
     self.toupee.shape = love.physics.newRectangleShape(self.toupee.width, self.toupee.height)
     self.toupee.fixture = love.physics.newFixture(self.toupee.body, self.toupee.shape, 1);
@@ -131,6 +137,7 @@ function Sam:init(world, mapObject)
     self.leftEye.radius = 2
     self.leftEye.image = love.graphics.newImage("assets/art/sam-textures/eye-right.png")
     self.leftEye.body = love.physics.newBody(world, spawn.x-7, spawn.y-51, "dynamic")
+    self.leftEye.body:setUserData("samBodyPart")
     self.leftEye.shape = love.physics.newCircleShape(self.leftEye.radius)
     self.leftEye.fixture = love.physics.newFixture(self.leftEye.body, self.leftEye.shape, 0.5);
     self.leftEye.fixture:setFriction(0.9)
@@ -145,6 +152,7 @@ function Sam:init(world, mapObject)
     self.rightEye.radius = 2
     self.rightEye.image = love.graphics.newImage("assets/art/sam-textures/eye-left.png")
     self.rightEye.body = love.physics.newBody(world, spawn.x+10, spawn.y-50, "dynamic")
+    self.rightEye.body:setUserData("samBodyPart")
     self.rightEye.shape = love.physics.newCircleShape(self.rightEye.radius)
     self.rightEye.fixture = love.physics.newFixture(self.rightEye.body, self.rightEye.shape, 0.5);
     self.rightEye.fixture:setFriction(0.9)
@@ -160,6 +168,7 @@ function Sam:init(world, mapObject)
     self.nose.height = 26
     self.nose.image = love.graphics.newImage("assets/art/sam-textures/nose.png")
     self.nose.body = love.physics.newBody(world, spawn.x+1, spawn.y-55, "dynamic")
+    self.nose.body:setUserData("samBodyPart")
     self.nose.shape = love.physics.newRectangleShape(self.nose.width, self.nose.height)
     self.nose.fixture = love.physics.newFixture(self.nose.body, self.nose.shape, 1);
     self.nose.fixture:setFriction(.8)
@@ -175,6 +184,7 @@ function Sam:init(world, mapObject)
     self.leftArm.height = 35
     self.leftArm.image = love.graphics.newImage("assets/art/sam-textures/arm-left.png")
     self.leftArm.body = love.physics.newBody(world, spawn.x-30, spawn.y, "dynamic")
+    self.leftArm.body:setUserData("samBodyPart")
     self.leftArm.shape = love.physics.newRectangleShape(self.leftArm.width, self.leftArm.height)
     self.leftArm.fixture = love.physics.newFixture(self.leftArm.body, self.leftArm.shape, 1);
     self.leftArm.fixture:setFriction(0.5)
@@ -190,6 +200,7 @@ function Sam:init(world, mapObject)
     self.leftHand = {}
     self.leftHand.image = love.graphics.newImage("assets/art/sam-textures/hand-left-open.png")
     self.leftHand.body = love.physics.newBody(world, spawn.x-30, spawn.y+self.leftArm.height+handToArmDistance, "dynamic")
+    self.leftHand.body:setUserData("samBodyPart")
     self.leftHand.shape = love.physics.newCircleShape(8)
     self.leftHand.fixture = love.physics.newFixture(self.leftHand.body, self.leftHand.shape, 1);
     self.leftHand.color = {0.8, 0.4, 1}
@@ -205,6 +216,7 @@ function Sam:init(world, mapObject)
     self.rightArm.height = 35
     self.rightArm.image = love.graphics.newImage("assets/art/sam-textures/arm-right.png")
     self.rightArm.body = love.physics.newBody(world, spawn.x+30, spawn.y, "dynamic")
+    self.rightArm.body:setUserData("samBodyPart")
     self.rightArm.shape = love.physics.newRectangleShape(self.rightArm.width, self.rightArm.height)
     self.rightArm.fixture = love.physics.newFixture(self.rightArm.body, self.rightArm.shape, 1);
     self.rightArm.fixture:setFriction(0.5)
@@ -218,6 +230,7 @@ function Sam:init(world, mapObject)
     self.rightHand = {}
     self.rightHand.image = love.graphics.newImage("assets/art/sam-textures/hand-right-open.png")
     self.rightHand.body = love.physics.newBody(world, spawn.x+30, spawn.y+self.rightArm.height+handToArmDistance, "dynamic")
+    self.rightHand.body:setUserData("samBodyPart")
     self.rightHand.shape = love.physics.newCircleShape(8)
     self.rightHand.fixture = love.physics.newFixture(self.rightHand.body, self.rightHand.shape, 1);
     self.rightHand.color = {0.8, 0.4, 1}

--- a/silly-sam/sam.lua
+++ b/silly-sam/sam.lua
@@ -255,8 +255,10 @@ function Sam:init(world, mapObject)
         self.rightLeg,
         self.leftArm,
         self.rightArm,
-        self.chin,
         self.nose,
+        self.leftEye,
+        self.rightEye,
+        self.chin,
         self.toupee,
         self.leftHand,
         self.rightHand,
@@ -275,6 +277,8 @@ function Sam:update(dt, controls)
     
     self:leftLegForces()
     self:rightLegForces()
+    
+    print(self.rightLeg.onGround)
 end
 
 function Sam:armForces(dt, arm, keyboardInputs, xaxis, yaxis)

--- a/silly-sam/sam.lua
+++ b/silly-sam/sam.lua
@@ -36,8 +36,6 @@ function Sam:init(world, mapObject)
     self.chest.fixture:setFriction(0.5)
     self.chest.color = {1, 1, 1}
 
-    self.chest.onGround = false
-
     -- left leg
     self.leftLeg = {}
     self.leftLeg.width = 17
@@ -60,8 +58,6 @@ function Sam:init(world, mapObject)
     self.leftLeg.joint:setLimitsEnabled(true)
     self.leftLeg.joint:setLimits(-5, 5)
 
-    self.leftLeg.onGround = false
-
     -- right leg
     self.rightLeg = {}
     self.rightLeg.width = 17
@@ -83,8 +79,6 @@ function Sam:init(world, mapObject)
     self.rightLeg.joint:setLimitsEnabled(true)
     self.rightLeg.joint:setLimits(-5, 5)
 
-    self.rightLeg.onGround = false
-
     -- head
     self.head = {}
     self.head.image = love.graphics.newImage("assets/art/sam-textures/face.png")
@@ -97,8 +91,6 @@ function Sam:init(world, mapObject)
 
     self.head.joint = love.physics.newRevoluteJoint(self.chest.body, self.head.body, spawn.x, spawn.y-65)
 
-    self.head.onGround = false
-
     -- chin (not visible, for weighting)
     self.chin = {}
     self.chin.body = love.physics.newBody(world, spawn.x, spawn.y-35, "dynamic")
@@ -110,8 +102,6 @@ function Sam:init(world, mapObject)
     self.chin.color = {0.80, 0.20, 0.20}
 
     self.chin.joint = love.physics.newWeldJoint(self.head.body, self.chin.body, spawn.x, spawn.y-65)
-
-    self.chin.onGround = false
 
     -- toupee
     self.toupee = {}
@@ -130,8 +120,6 @@ function Sam:init(world, mapObject)
     
     -- self.toupee.joint:enableLimit(enable) trying to enable limit on joint
 
-    self.toupee.onGround = false
-
     -- left eye
     self.leftEye = {}
     self.leftEye.radius = 2
@@ -145,8 +133,6 @@ function Sam:init(world, mapObject)
 
     self.leftEye.joint = love.physics.newRevoluteJoint(self.leftEye.body, self.head.body, spawn.x, spawn.y-51)
 
-    self.leftEye.onGround = false
-
     -- right eye
     self.rightEye = {}
     self.rightEye.radius = 2
@@ -159,8 +145,6 @@ function Sam:init(world, mapObject)
     self.rightEye.color = {0.20, 0.70, 0.20}
 
     self.rightEye.joint = love.physics.newRevoluteJoint(self.rightEye.body, self.head.body, spawn.x+7, spawn.y-56)
-
-    self.rightEye.onGround = false
 
     -- nose
     self.nose = {}
@@ -176,8 +160,6 @@ function Sam:init(world, mapObject)
 
     self.nose.joint = love.physics.newRevoluteJoint(self.nose.body, self.head.body, spawn.x+1, spawn.y-66)
 
-    self.nose.onGround = false
-
     -- left arm
     self.leftArm = {}
     self.leftArm.width = 20
@@ -191,8 +173,6 @@ function Sam:init(world, mapObject)
     self.leftArm.color = {0.1, 0.4, 1}
 
     self.leftArm.joint = love.physics.newRevoluteJoint(self.chest.body, self.leftArm.body, spawn.x-30, spawn.y-10)
-
-    self.leftArm.onGround = false
 
     local handToArmDistance = -8
 
@@ -224,8 +204,6 @@ function Sam:init(world, mapObject)
 
     self.rightArm.joint = love.physics.newRevoluteJoint(self.chest.body, self.rightArm.body, spawn.x+30, spawn.y-10)
 
-    self.rightArm.onGround = false
-
     -- left hand
     self.rightHand = {}
     self.rightHand.image = love.graphics.newImage("assets/art/sam-textures/hand-right-open.png")
@@ -240,7 +218,7 @@ function Sam:init(world, mapObject)
     -- physics not applied - for checking collisions on 'grabbing'
     self.rightHand.fixture:setSensor(true)
 
-    -- this is for drawing
+    -- These are for drawing
     self.rectParts = {
         self.leftLeg,
         self.rightLeg,
@@ -260,23 +238,6 @@ function Sam:init(world, mapObject)
         self.rightHand,
     }
 
-    -- for logic
-    self.allParts = {
-        self.head,
-        self.chest,
-        self.leftLeg,
-        self.rightLeg,
-        self.leftArm,
-        self.rightArm,
-        self.nose,
-        self.leftEye,
-        self.rightEye,
-        self.chin,
-        self.toupee,
-        self.leftHand,
-        self.rightHand,
-    }
-
     self.yPrevLeftFactor = 0
     self.yPrevRightFactor = 0
 
@@ -291,7 +252,7 @@ function Sam:update(dt, controls)
     self:leftLegForces()
     self:rightLegForces()
     
-    print(self.rightLeg.onGround)
+    print(self:bodyPartHasGroundContact(self.rightLeg))
 end
 
 function Sam:armForces(dt, arm, keyboardInputs, xaxis, yaxis)
@@ -329,7 +290,8 @@ function Sam:armForces(dt, arm, keyboardInputs, xaxis, yaxis)
     local pushThreshold = -20*dt
 
     if xaxis == "leftx" then
-        if arm.onGround and (yFactor - self.yPrevLeftFactor) < pushThreshold then
+
+        if self:bodyPartHasGroundContact(arm) and (yFactor - self.yPrevLeftFactor) < pushThreshold then
             forceFactor = self.statics.pushForce*dt
     
             -- don't want any horizontal
@@ -338,7 +300,8 @@ function Sam:armForces(dt, arm, keyboardInputs, xaxis, yaxis)
     
         self.yPrevLeftFactor = yFactor
     elseif xaxis == "rightx" then
-        if arm.onGround and (yFactor - self.yPrevRightFactor) < pushThreshold then
+
+        if self:bodyPartHasGroundContact(arm) and (yFactor - self.yPrevRightFactor) < pushThreshold then
             forceFactor = self.statics.pushForce*dt
             xFactor = 0
         end
@@ -413,7 +376,7 @@ function Sam:rightLegForces()
 end
 
 function Sam:moveLeft()
-    if self.leftLeg.onGround then
+    if self:bodyPartHasGroundContact(self.leftLeg) then
         self:forceUpLeg(self.leftLeg)
 
         -- shove a little bit left as well to help travelling
@@ -422,7 +385,7 @@ function Sam:moveLeft()
 end
 
 function Sam:moveRight()
-    if self.rightLeg.onGround then
+    if self:bodyPartHasGroundContact(self.rightLeg) then
         self:forceUpLeg(self.rightLeg)
         
         -- shove a little bit right as well to help travelling
@@ -482,6 +445,48 @@ function Sam:handRelease(hand)
     if hand.worldJoint and not hand.worldJoint:isDestroyed() then
         hand.worldJoint:destroy()
     end
+end
+
+function Sam:bodyPartHasGroundContact(bodyPart)
+    -- Check through fixture's contacts and see if any of them are non-sam's bodies
+    
+    local groundContactExists = false
+    local contacts = bodyPart.body:getContacts()
+
+    -- Need to check no other connections to body1 are non-sam bodies, otherwise we are touching
+    for contactIndex in pairs(contacts) do
+        
+        if contacts[contactIndex]:isTouching() then
+            fixture1, fixture2 = contacts[contactIndex]:getFixtures()
+
+            -- If we find one, we want to stop checking
+            if not groundContactExists then
+                if fixture1:getBody() ~= body1 then
+                    groundContactExists = self:fixtureBodyIsGround(fixture1)
+                end
+
+                if fixture2:getBody() ~= body1 then
+                    groundContactExists = self:fixtureBodyIsGround(fixture2)
+                end
+            end
+        end
+    end
+
+    print('ground contact: ', groundContactExists)
+
+    return groundContactExists
+end
+
+
+function Sam:fixtureBodyIsGround(fixture)
+    -- Check if it's a sam body part. If not, we're contacting with the ground
+    print('Fixture body data:', fixture:getBody():getUserData())
+
+    partOfSamsBody = fixture:getBody():getUserData() == "samBodyPart"
+
+    print('fixture body in sam?', partOfSamsBody)
+
+    return not partOfSamsBody
 end
 
 function Sam:draw(drawShapes, drawSprites)

--- a/silly-sam/states/gameState.lua
+++ b/silly-sam/states/gameState.lua
@@ -25,12 +25,12 @@ local function checkStaticBool(static)
 end
 
 function GameState:init()
-    --self:loadMap("maps/intro-map.lua")
+    self:loadMap("maps/intro-map.lua")
     --self:loadMap("maps/survival-map.lua")
     --self:loadMap("maps/cliff.lua")
     --self:loadMap("maps/swinging.lua")
     --self:loadMap("maps/bonus.lua")
-    self:loadMap("maps/rory-level.lua")
+    --self:loadMap("maps/rory-level.lua")
     
     --self:loadMap("maps/test-map-limited-level.lua")
 

--- a/silly-sam/states/gameState.lua
+++ b/silly-sam/states/gameState.lua
@@ -280,79 +280,17 @@ end
 
 -- Should these should all be in a physics helper?
 function GameState:beginContact(fixture1, fixture2, contact)
-    -- check the contact created is actually touching
-    if not contact:isTouching() then
-        return
-    end
-    
-    self:bodyOnGround(fixture1:getBody(), fixture2:getBody())
-    self:bodyOnGround(fixture2:getBody(), fixture1:getBody())
+    -- If I did anything here, first I'd need to check the contact created is actually touching
+    -- if not contact:isTouching() then
+    --     return
+    -- end
 end
 
 function GameState:endContact(fixture1, fixture2, contact)
-    self:bodyOnGround(fixture1:getBody(), fixture2:getBody())
-    self:bodyOnGround(fixture2:getBody(), fixture1:getBody())
-
     -- make sure garbage is collected properly: https://love2d.org/forums/viewtopic.php?t=9643
     collectgarbage()
 end
 
-function GameState:bodyOnGround(body1, body2)
-    local isBody1Part = body1:getUserData() == "samBodyPart"
-    local isBody2Part = body2:getUserData() == "samBodyPart"
-
-    -- if trigger was a body part hitting a non body part react
-    if isBody1Part and not isBody2Part then
-        for i in pairs(self.sam.allParts) do
-            if self.sam.allParts[i].body == body1 then
-                self.sam.allParts[i].onGround = self.sam.allParts[i].body:isTouching(body2)
-
-                local groundContactExists = false
-                local contacts = body1:getContacts()
-
-                -- Need to check no other connections to body1 are non-sam bodies, otherwise we are touching
-                for contactIndex in pairs(contacts) do
-                    fixture1, fixture2 = contacts[contactIndex]:getFixtures()
-
-                    -- Don't want to count the body we're no longer colliding with, since it'll still be in the contacts list but it's already been acounted for
-                    if fixture1:getBody() ~= body2 and fixture2:getBody() ~= body2 then
-                        -- If we find one, we want to stop checking
-                        if not groundContactExists then
-                            if fixture1:getBody() ~= body1 then
-                                groundContactExists = self:fixtureBodyIsGround(fixture1)
-                            end
-
-                            if fixture2:getBody() ~= body1 then
-                                groundContactExists = self:fixtureBodyIsGround(fixture2)
-                            end
-                        end
-                    end
-                end
-
-                print('ground contact: ', groundContactExists)
-
-                -- If we found that the body owns a ground contact, this body part is on the ground
-                if groundContactExists then
-                    self.sam.allParts[i].onGround = groundContactExists
-                end
-            end
-        end
-    end
-end
-
-function GameState:fixtureBodyIsGround(fixture)
-    -- Check if it's a sam body part. If not, we're contacting with the ground
-    print('Fixture body data:', fixture:getBody():getUserData())
-
-    partOfSamsBody = fixture:getBody():getUserData() == "samBodyPart"
-
-    print('fixture body in sam?', partOfSamsBody)
-
-    return not partOfSamsBody
-end
-
-
--- what are these?
 function GameState:preSolve(fixture1, fixture2, contact)
 end
 

--- a/silly-sam/toys/ball.lua
+++ b/silly-sam/toys/ball.lua
@@ -11,6 +11,7 @@ function Ball:init(world, mapObject)
     local bodyType = self:checkStaticBool(mapObject.properties.static)
 
     self.body = love.physics.newBody(world, xSpawn, ySpawn, bodyType)
+    self.body:setUserData("ball")
     self.shape = love.physics.newCircleShape(radius)
     self.fixture = love.physics.newFixture(self.body, self.shape, 0.5);
     self.fixture:setFriction(0.5)

--- a/silly-sam/toys/explodingPlatform.lua
+++ b/silly-sam/toys/explodingPlatform.lua
@@ -40,6 +40,7 @@ end
 function ExplodingPlatform:resetPhysicsObject(world)
     -- [re]-create based on saved values
     self.body = love.physics.newBody(world, self.xSpawn, self.ySpawn, self.bodyType)
+    self.body:setUserData("explodingPlatform")
     self.shape = love.physics.newRectangleShape(0, 0, self.width, self.height)
     self.fixture = love.physics.newFixture(self.body, self.shape);
     self.fixture:setFriction(0.9)

--- a/silly-sam/toys/hangingBag.lua
+++ b/silly-sam/toys/hangingBag.lua
@@ -15,6 +15,7 @@ function HangingBag:init(world, mapObject)
     -- create a static anchor point
     self.anchor = {}
     self.anchor.body = love.physics.newBody(world, xSpawn, ySpawn, "static")
+    self.anchor.body:setUserData("hangingBagAnchor")
     self.anchor.shape = love.physics.newCircleShape(5)
     self.anchor.fixture = love.physics.newFixture(self.anchor.body, self.anchor.shape, 0.5);
     self.anchor.fixture:setFriction(0.5)
@@ -23,6 +24,7 @@ function HangingBag:init(world, mapObject)
     self.bag = {}
     self.bag.width, self.bag.height = mapObject.properties.bagWidth, mapObject.properties.bagHeight
     self.bag.body = love.physics.newBody(world, xSpawn, ySpawn+ropeLength, "dynamic")
+    self.bag.body:setUserData("hangingBag")
     self.bag.shape = love.physics.newRectangleShape(0, 0, self.bag.width, self.bag.height)
     self.bag.fixture = love.physics.newFixture(self.bag.body, self.bag.shape, 0.5);
     self.bag.fixture:setFriction(0.5)
@@ -37,6 +39,7 @@ function HangingBag:init(world, mapObject)
         -- create another object between the bag and the rope to allow the bag to rotate around the join to the rope
         self.bagPivotPoint = {}
         self.bagPivotPoint.body = love.physics.newBody(world, xSpawn, ySpawn+ropeLength-self.bag.height/2, "dynamic")
+        self.bagPivotPoint.body:setUserData("bagPivotPoint")
         self.bagPivotPoint.shape = love.physics.newCircleShape(5)
         self.bagPivotPoint.fixture = love.physics.newFixture(self.bagPivotPoint.body, self.bagPivotPoint.shape, 0.5);
         self.bagPivotPoint.fixture:setFriction(0.5)

--- a/silly-sam/toys/rectangle.lua
+++ b/silly-sam/toys/rectangle.lua
@@ -13,6 +13,7 @@ function Rectangle:init(world, mapObject)
     local bodyType = self:checkStaticBool(mapObject.properties.static)
 
     self.body = love.physics.newBody(world, xSpawn, ySpawn, bodyType)
+    self.body:setUserData("rectangle")
     self.shape = love.physics.newRectangleShape(0, 0, self.width, self.height)
     self.fixture = love.physics.newFixture(self.body, self.shape);
     self.fixture:setFriction(0.9)

--- a/silly-sam/toys/skateboard.lua
+++ b/silly-sam/toys/skateboard.lua
@@ -11,6 +11,7 @@ function Skateboard:init(world, mapObject)
     self.board = {}
     self.board.width, self.board.height = 100, 5
     self.board.body = love.physics.newBody(world, xSpawn, ySpawn, "dynamic")
+    self.board.body:setUserData("skateboard")
     self.board.shape = love.physics.newRectangleShape(0, 0, self.board.width, self.board.height)
     self.board.fixture = love.physics.newFixture(self.board.body, self.board.shape);
     self.board.fixture:setFriction(0.9)
@@ -34,6 +35,7 @@ function Skateboard:init(world, mapObject)
     -- left wheel
     self.leftWheel = {}
     self.leftWheel.body = love.physics.newBody(world, xLeftWheelSpawn, yLeftWheelSpawn, "dynamic")
+    self.leftWheel.body:setUserData("skateboardLeftWheel")
     self.leftWheel.shape = love.physics.newCircleShape(wheelRadius)
     self.leftWheel.fixture = love.physics.newFixture(self.leftWheel.body, self.leftWheel.shape, 0.5);
     self.leftWheel.fixture:setFriction(0.5)
@@ -47,6 +49,7 @@ function Skateboard:init(world, mapObject)
     self.rightWheel = {}
 
     self.rightWheel.body = love.physics.newBody(world, xRightWheelSpawn, yRightWheelSpawn, "dynamic")
+    self.rightWheel.body:setUserData("skateboardRightWheel")
     self.rightWheel.shape = love.physics.newCircleShape(wheelRadius)
     self.rightWheel.fixture = love.physics.newFixture(self.rightWheel.body, self.rightWheel.shape, 0.5);
     self.rightWheel.fixture:setFriction(0.5)


### PR DESCRIPTION
Had issues with the onGround logic getting confused. Instead of keeping state and updating when collisions occur, checking what collisions exist when the inputs are done to see if the appropriate part is on ground or not. Using the body's userData to simplify logic. Seems more stable.